### PR TITLE
Add String::Random as required module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ default:
 .PHONY: install
 install:
 	if [ "$${INSTALL_DEPS:-1}" = "1" ]; then \
-		cpan install XML::Writer Net::Netmask Net::IP Net::DNS Net::Whois::IP HTML::Parser WWW::Mechanize; \
+		cpan install XML::Writer Net::Netmask Net::IP Net::DNS Net::Whois::IP HTML::Parser WWW::Mechanize String::Random; \
 	fi
 	install -D -m 644 dns.txt -t $(DESTDIR)/usr/share/dnsenum/
 	install -D -m 644 dnsenum.1 -t $(DESTDIR)/usr/share/man/man1/

--- a/README.md
+++ b/README.md
@@ -38,17 +38,20 @@ and to discover non-contiguous ip blocks.
 - Modules that are included in perl 5.28.0:
 
   - Getopt::Long
-  - IO::File \* Thread::Queue
+  - IO::File
+  - Thread::Queue
 
 - Other Necessary modules:
   - Must have:
-  - Net::IP
-  - Net::DNS
-  - Net::Netmask
+    - Net::IP
+    - Net::DNS
+    - Net::Netmask
+    - String::Random
   - Optional:
-  - Net::Whois::IP
-  - HTML::Parser
-  - WWW::Mechanize \* XML::Writer
+    - Net::Whois::IP
+    - HTML::Parser
+    - WWW::Mechanize
+    - XML::Writer
 
 ## INSTALLATION:
 


### PR DESCRIPTION
Found that I could not run the script without String::Random, so added it to the README and Makefile. Also fixed the list formatting in the README.